### PR TITLE
fix syntax errors in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "esri reveal.js templates",
+  "name": "esri-reveal.js-templates",
   "version": "3.6.0",
   "description": "reveal.js templates that look like official powerpoint templates for esri conferences",
   "main": "js/reveal.js",
@@ -10,7 +10,7 @@
   },
   "author": {
     "name": "John Gravois",
-    "email": "john@esri.com",
+    "email": "john@esri.com"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I was getting package.json parse errors when trying to run `npm i`, this PR fixes that.