### PR TITLE
fix(gulp): reload nested index.html too

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -283,7 +283,7 @@ gulp.task('package', gulp.series(() =>
 
 ))
 
-gulp.task('reload', () => gulp.src(['index.html'])
+gulp.task('reload', () => gulp.src(['**/index.html'])
     .pipe(connect.reload()));
 
 gulp.task('serve', () => {


### PR DESCRIPTION
See https://github.com/Esri/reveal.js/issues/25#issuecomment-1839076236

Makes the gulp reload task watch for nested index.html files too.

Without this, hot reloading does not work in my project (since my index.html are nested) and I was getting this error:

```yaml
[08:47:02] Starting 'reload'...
[08:47:02] 'reload' errored after 21 ms
[08:47:02] Error: File not found with singular glob: /Users/mak13180/site/esri/esri-dev-summit-presentations/index.html (if this was purposeful, use `allowEmpty` option)
    at Glob.<anonymous> (/Users/mak13180/site/esri/esri-dev-summit-presentations/2024/reveal.js/node_modules/glob-stream/readable.js:84:17)
    at Object.onceWrapper (node:events:629:26)
    at Glob.emit (node:events:514:28)
    at Glob.emit (node:domain:489:12)
    at Glob._finish (/Users/mak13180/site/esri/esri-dev-summit-presentations/2024/reveal.js/node_modules/glob-stream/node_modules/glob/glob.js:194:8)
    at done (/Users/mak13180/site/esri/esri-dev-summit-presentations/2024/reveal.js/node_modules/glob-stream/node_modules/glob/glob.js:179:14)
    at Glob._processSimple2 (/Users/mak13180/site/esri/esri-dev-summit-presentations/2024/reveal.js/node_modules/glob-stream/node_modules/glob/glob.js:688:12)
    at /Users/mak13180/site/esri/esri-dev-summit-presentations/2024/reveal.js/node_modules/glob-stream/node_modules/glob/glob.js:676:10
    at Glob._stat2 (/Users/mak13180/site/esri/esri-dev-summit-presentations/2024/reveal.js/node_modules/glob-stream/node_modules/glob/glob.js:772:12)
    at lstatcb_ (/Users/mak13180/site/esri/esri-dev-summit-presentations/2024/reveal.js/node_modules/glob-stream/node_modules/glob/glob.js:764:12)
```